### PR TITLE
Add find_benefit_claim_detail endpoint

### DIFF
--- a/lib/bgs/services/benefit.rb
+++ b/lib/bgs/services/benefit.rb
@@ -13,5 +13,11 @@ module BGS
 
       response.body[:find_benefit_claim_response][:return][:participant_record][:selection] || []
     end
+
+    def find_claim_detail_by_id(id)
+      response = request(:find_benefit_claim_detail, "benefitClaimId": id)
+
+      response.body[:find_benefit_claim_detail_response][:return] || []
+    end
   end
 end


### PR DESCRIPTION
This enables us to identify when a claim was first established (and other details, including the station that established it).