### PR TITLE
Add read/open timeout for Savon

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -102,7 +102,9 @@ module BGS
         wsdl: wsdl, soap_header: header, log: @log,
         ssl_cert_key_file: @ssl_cert_key_file,
         ssl_cert_file: @ssl_cert_file,
-        ssl_ca_cert_file: @ssl_ca_cert
+        ssl_ca_cert_file: @ssl_ca_cert,
+        open_timeout: 30, # in seconds
+        read_timeout: 30 # in seconds
       )
     end
 


### PR DESCRIPTION
This adds read/open timeouts to BGS. Setting them very conservatively to 30seconds for now. This just ensures the threads are eventually freed up

connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/429

Testing:
- [x] Connected locally used this branch and we able to make a successful BGS request