### PR TITLE
Implement find address by participant ID

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -113,7 +113,7 @@ module BGS
       client.call(method, message: message)
     rescue Savon::SOAPFault => error
       exception_detail = error.to_hash[:fault][:detail]
-      raise e unless exception_detail.key? :share_exception
+      raise error unless exception_detail.key? :share_exception
       raise BGS::ShareError, exception_detail[:share_exception][:message]
     end
   end

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -20,6 +20,7 @@ require "bgs/services/awards"
 require "bgs/services/benefit"
 require "bgs/services/veteran"
 require "bgs/services/standard_data"
+require "bgs/services/address"
 
 # Now, we're going to declare a class to hide the actual creation of service
 # objects, since having to construct them all really sucks.

--- a/lib/bgs/services/address.rb
+++ b/lib/bgs/services/address.rb
@@ -1,0 +1,20 @@
+# As a work of the United States Government, this project is in the
+# public domain within the United States.
+#
+# Additionally, we waive copyright and related rights in the work
+# worldwide through the CC0 1.0 Universal public domain dedication.
+
+module BGS
+  # This service is used to find the address information.
+  class AddressWebService < BGS::Base
+    def self.service_name
+      "address"
+    end
+
+    # Finds a PTCPNT_ADDRS row for the given ptcpnt_id and address type
+    def find_by_participant_id(participant_id)
+      response = request(:find_ptcpnt_addrs, "ptcpntId": participant_id, "ptcpntAddrsTypeNm": "Mailing")
+      response.body[:find_ptcpnt_addrs_response][:return]
+    end
+  end
+end

--- a/lib/bgs/services/address.rb
+++ b/lib/bgs/services/address.rb
@@ -13,7 +13,9 @@ module BGS
 
     # Finds a PTCPNT_ADDRS row for the given ptcpnt_id and address type
     def find_by_participant_id(participant_id)
-      response = request(:find_ptcpnt_addrs, "ptcpntId": participant_id, "ptcpntAddrsTypeNm": "Mailing")
+      response = request(
+        :find_ptcpnt_addrs, "ptcpntId": participant_id, "ptcpntAddrsTypeNm": "Mailing"
+      )
       response.body[:find_ptcpnt_addrs_response][:return]
     end
   end


### PR DESCRIPTION
connects #32 

We need to send address type. So far I only found "Mailing" address type. 

Example:

```
 bgs.address.find_by_participant_id("600085544")

{:addrs_one_txt=>"1000 MISSION ST",
 :addrs_three_txt=>"APT 2",
 :addrs_two_txt=>"UBER",
 :city_nm=>"SAN FRANCISCO",
 :cntry_nm=>"USA",
 :efctv_dt=>#<DateTime: 2017-04-04T15:38:31-05:00 ((2457848j,74311s,0n),-18000s,2299161j)>,
 :jrn_dt=>#<DateTime: 2017-05-15T09:59:37-05:00 ((2457889j,53977s,0n),-18000s,2299161j)>,
 :jrn_lctn_id=>"283",
 :jrn_obj_id=>"SHARE  - PCAN",
 :jrn_status_type_cd=>"U",
 :jrn_user_id=>"CASEFLOW1",
 :postal_cd=>"CA",
 :ptcpnt_addrs_id=>"15069061",
 :ptcpnt_addrs_type_nm=>"Mailing",
 :ptcpnt_id=>"600085544",
 :shared_addrs_ind=>"N",
 :trsury_addrs_four_txt=>"SAN FRANCISCO CA",
 :trsury_addrs_one_txt=>"Lilly Arden",
 :trsury_addrs_three_txt=>"UBER APT 2",
 :trsury_addrs_two_txt=>"1000 MISSION ST",
 :trsury_seq_nbr=>"5",
 :zip_prefix_nbr=>"94103"}
```