### PR TITLE
Include veteran service information in BGS response

### DIFF
--- a/lib/bgs/services/veteran.rb
+++ b/lib/bgs/services/veteran.rb
@@ -19,7 +19,9 @@ module BGS
       response = request(:find_veteran_by_file_number, "fileNumber": file_number)
       response = response.body[:find_veteran_by_file_number_response][:return]
 
-      response[:vet_corp_record].merge(sex: response[:vet_birls_record][:sex_code])
+      response[:vet_birls_record]
+        .merge(response[:vet_corp_record])
+        .merge(sex: response[:vet_birls_record][:sex_code])
     end
   end
 end


### PR DESCRIPTION
- Merge in `vet_birls_record` to our response from BGS so that we have
  information regarding the Veteran's periods of service

#### Test Plan
- Ran the code on a UAT instance. I verified the existing keys we use (like ssn, state, etc) still exist in the response. Also verified that the new key we need `service` is returned:
<img width="1680" alt="screen shot 2017-08-04 at 5 00 21 pm" src="https://user-images.githubusercontent.com/2256237/28986858-cdbb63e8-7936-11e7-9dd9-c76072340e57.png">
