### PR TITLE
[WIP] Bump savon version for header support in WSDLRequest

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = ""
 
   gem.add_runtime_dependency "nokogiri", "~> 1.8.1"
-  gem.add_runtime_dependency "savon", "~> 2.11"
+  gem.add_runtime_dependency "savon", "~> 2.12"
 
   gem.files         = Dir["lib/**/*.rb"]
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Use a more recent version of the savon dependency.

The latest release of is 2.11.2, which does not include a `WSDLRequest` [headers feature](https://github.com/savonrb/savon/commit/2bd15efbda56f) that was subsequently accepted and essential for the proxy implementation.

The small change in this PR does the trick of pulling in a more recent version, although it is not yet tagged as a release. 

Verified by building the `bgs` gem and then installing it in another application; found the installed copy of `savon-2.12.0/lib/savon/request.rb` contains the `WSDLRequest` headers feature.

This approach seems to work, to my surprise. I had expected to need to specify a github url and SHA. Not sure which approach is better.