### PR TITLE
Make WSDLRequest apply the host header

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -128,6 +128,8 @@ module BGS
         open_timeout: 30, # in seconds
         read_timeout: 30 # in seconds
       )
+      # can be removed when savon > 2.11.2 is released
+      @client.wsdl.request.headers = headers
     end
 
     # Proxy to call a method on our web service.

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -133,9 +133,7 @@ module BGS
     # Proxy to call a method on our web service.
     def request(method, message = nil)
       # can be removed when savon > 2.11.2 is released
-      if @forward_proxy_url
-        client.wsdl.request.headers = {"Host" => domain}
-      end
+      client.wsdl.request.headers = { "Host" => domain } if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => error
       exception_detail = error.to_hash[:fault][:detail]

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -128,12 +128,14 @@ module BGS
         open_timeout: 30, # in seconds
         read_timeout: 30 # in seconds
       )
-      # can be removed when savon > 2.11.2 is released
-      @client.wsdl.request.headers = headers
     end
 
     # Proxy to call a method on our web service.
     def request(method, message = nil)
+      # can be removed when savon > 2.11.2 is released
+      if @forward_proxy_url
+        client.wsdl.request.headers = {"Host" => domain}
+      end
       client.call(method, message: message)
     rescue Savon::SOAPFault => error
       exception_detail = error.to_hash[:fault][:detail]


### PR DESCRIPTION
Apply the host header to each wsdl request. (thanks to @kierachell for figuring this out)

The `savon` library introduced a [feature](https://github.com/savonrb/savon/commit/2bd15efbda56fe4ca3d5d7cd27b6cd5aac98f651) on `WSDLRequest` that allows the client to define global headers for wsdl requests, but this version of the library has not been released. 