### PR TITLE
Allow Envoy to finish its retries

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -125,8 +125,8 @@ module BGS
         headers: headers,
         ssl_cert_file: @ssl_cert_file,
         ssl_ca_cert_file: @ssl_ca_cert,
-        open_timeout: 30, # in seconds
-        read_timeout: 30 # in seconds
+        open_timeout: 600, # in seconds
+        read_timeout: 600 # in seconds
       )
     end
 


### PR DESCRIPTION
Mimic what's in connect_vva to allow Envoy to finish its retries: https://github.com/department-of-veterans-affairs/connect_vva/blob/master/lib/vva/base.rb#L77