### PR TITLE
Re-throw original error if no detailed message

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -138,9 +138,10 @@ module BGS
     rescue Savon::SOAPFault => error
       exception_detail = error.to_hash[:fault][:detail]
 
-      # Only test the existence of these two elements (detail and share_exception) because we expect 'fault' will
-      # always be defined if a Savon::SOAPFault error is thrown, and 'message' being undefined is fine with us.
-      raise error unless exception_detail && exception_detail.key? :share_exception
+      # Only test the existence of these two elements (detail and share_exception) because we
+      # expect 'fault' will always be defined if a Savon::SOAPFault error is thrown, and 'message'
+      # being undefined is fine with us.
+      raise error unless exception_detail && exception_detail.key?(:share_exception)
       raise BGS::ShareError, exception_detail[:share_exception][:message]
     end
   end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -136,11 +136,12 @@ module BGS
       client.wsdl.request.headers = { "Host" => domain } if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => error
-      begin
-        raise BGS::ShareError, error.to_hash[:fault][:detail][:share_exception][:message]
-      rescue NoMethodError
-        raise error
-      end
+      exception_detail = error.to_hash[:fault][:detail]
+
+      # Only test the existence of these two elements (detail and share_exception) because we expect 'fault' will
+      # always be defined if a Savon::SOAPFault error is thrown, and 'message' being undefined is fine with us.
+      raise error unless exception_detail && exception_detail.key? :share_exception
+      raise BGS::ShareError, exception_detail[:share_exception][:message]
     end
   end
 end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -136,9 +136,12 @@ module BGS
       client.wsdl.request.headers = { "Host" => domain } if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => error
-      exception_detail = error.to_hash[:fault][:detail]
-      raise error unless exception_detail.key? :share_exception
-      raise BGS::ShareError, exception_detail[:share_exception][:message]
+      begin
+        raise BGS::ShareError, error.to_hash[:fault][:detail][:share_exception][:message]
+      rescue NoMethodError
+        raise error
+      end
+      raise error
     end
   end
 end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -141,7 +141,6 @@ module BGS
       rescue NoMethodError
         raise error
       end
-      raise error
     end
   end
 end


### PR DESCRIPTION
Resolves the `NoMethodError: undefined method `key?' for nil:NilClass` error at the heart of this sentry error: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/675/

If `error.to_hash[:fault][:detail]` was not defined then the check for the `:share_exception` key would throw the `NoMethodError: undefined method `key?' for nil:NilClass` error.

This change fixes that by moving the entire detailed method parsing into a single step. If any of the elements in that hierarchy are undefined ruby will throw a `NoMethodError` which we will catch and throw the original `Savon::SOAPFault` error.