### PR TITLE
Rethrow SOAPFault logon errors as StandardError with public_message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem "rake"
 group :development, :test do
   gem "bundler-audit", git: "https://github.com/rubysec/bundler-audit"
   gem "pry"
+  gem "rspec"
   gem "rubocop"
 end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -19,6 +19,15 @@ module BGS
     end
   end
 
+  class PublicError < StandardError
+    attr_accessor :public_message
+
+    def initialize(message)
+      @public_message = message
+      super
+    end
+  end
+
   # This class is a base-class from which most Web Services will inherit.
   # This contains the basics of how to talk with the BGS SOAP API, in
   # particular, the VA's custom SOAP headers for auditing. As a bonus, it's

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -67,6 +67,12 @@ module BGS
     def can_access?(ssn)
       claimants.find_flashes(ssn).nil?
       return true
+    rescue Savon::SOAPFault => e
+      # Expect error string to look something like the following:
+      # Savon::SOAPFault: (S:Client) ID: {{UUID}}: Logon ID {{CSS_ID}} Not Found
+      # Only extract the final clause of that error message for the public error.
+      raise(BGS::PublicError, "#{$1} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS.") if e.to_s =~ /(Logon ID .* Not Found)/
+      raise e
     rescue BGS::ShareError
       return false
     end

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -66,15 +66,18 @@ module BGS
     # name changes.
     def can_access?(ssn)
       claimants.find_flashes(ssn).nil?
-      return true
+      true
     rescue Savon::SOAPFault => e
       # Expect error string to look something like the following:
       # Savon::SOAPFault: (S:Client) ID: {{UUID}}: Logon ID {{CSS_ID}} Not Found
       # Only extract the final clause of that error message for the public error.
-      raise(BGS::PublicError, "#{$1} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS.") if e.to_s =~ /(Logon ID .* Not Found)/
+      #
+      # rubocop:disable Metrics/LineLength
+      raise(BGS::PublicError, "#{Regexp.last_match(1)} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS.") if e.to_s =~ /(Logon ID .* Not Found)/
+      # rubocop:enable Metrics/LineLength
       raise e
     rescue BGS::ShareError
-      return false
+      false
     end
   end
 end

--- a/spec/bgs/services_spec.rb
+++ b/spec/bgs/services_spec.rb
@@ -1,5 +1,6 @@
 require "bgs"
 
+# rubocop:disable Metrics/BlockLength
 describe BGS::Services do
   let(:file_number) { "123456789" }
   let(:bgs_client) do
@@ -51,16 +52,21 @@ describe BGS::Services do
    </soap:Body>
 </soap:Envelope>)
     end
-    let(:error_string) { "#{fault_string} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS." }
+    let(:error_string) do
+      # rubocop:disable Metrics/LineLength
+      "#{fault_string} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS."
+      # rubocop:enable Metrics/LineLength
+    end
 
     it "BGS::Services.can_access? raises a BGS::PublicError that has a public_message" do
       allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_flashes).and_raise(soap_fault)
 
-      expect { bgs_client.can_access?(file_number) }.to raise_error { |error|
+      expect { bgs_client.can_access?(file_number) }.to raise_error do |error|
         expect(error).to be_a(BGS::PublicError)
         expect(error).to respond_to(:public_message)
         expect(error.public_message).to eq(error_string)
-      }
+      end
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/bgs/services_spec.rb
+++ b/spec/bgs/services_spec.rb
@@ -1,0 +1,66 @@
+require "bgs"
+
+describe BGS::Services do
+  let(:file_number) { "123456789" }
+  let(:bgs_client) do
+    BGS::Services.new(
+      env: "beplinktest",
+      application: "TEST_APP",
+      client_ip: "127.0.0.1",
+      client_station_id: 283,
+      client_username: "VACOUSERT",
+      forward_proxy_url: nil,
+      log: true
+    )
+  end
+
+  # Build Savon::SOAPFaults how the library builds them.
+  # https://github.com/savonrb/savon/blob/e76ecc00b84b998b012ecc33b55ca1edd443ec55/spec/savon/soap_fault_spec.rb
+  let(:response_body) { nil }
+  let(:http_response) { HTTPI::Response.new(500, {}, response_body) }
+  let(:nori) { Nori.new(strip_namespaces: true, convert_tags_to: ->(tag) { tag.snakecase.to_sym }) }
+  let(:soap_fault) { Savon::SOAPFault.new(http_response, nori) }
+
+  context "When BGS::ClaimantWebService.find_flashes() raises a generic Savon::SoapFault" do
+    let(:response_body) do
+      %(<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+   <soap:Body>
+      <soap:Fault>
+         <faultcode>soap:Server</faultcode>
+         <faultstring>Fault occurred while processing.</faultstring>
+      </soap:Fault>
+   </soap:Body>
+</soap:Envelope>)
+    end
+
+    it "BGS::Services.can_access? raises a Savon::SOAPFault" do
+      allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_flashes).and_raise(soap_fault)
+      expect { bgs_client.can_access?(file_number) }.to raise_error(Savon::SOAPFault)
+    end
+  end
+
+  context "When BGS::ClaimantWebService.find_flashes() raises a logon not found error" do
+    let(:fault_string) { "Logon ID VACOHSOLO Not Found" }
+    let(:response_body) do
+      %(<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+   <soap:Body>
+      <soap:Fault>
+         <faultcode>soap:Server</faultcode>
+         <faultstring>#{fault_string}</faultstring>
+      </soap:Fault>
+   </soap:Body>
+</soap:Envelope>)
+    end
+    let(:error_string) { "#{fault_string} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS." }
+
+    it "BGS::Services.can_access? raises a BGS::PublicError that has a public_message" do
+      allow_any_instance_of(BGS::ClaimantWebService).to receive(:find_flashes).and_raise(soap_fault)
+
+      expect { bgs_client.can_access?(file_number) }.to raise_error { |error|
+        expect(error).to be_a(BGS::PublicError)
+        expect(error).to respond_to(:public_message)
+        expect(error.public_message).to eq(error_string)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Connects [efolder #946](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/946).