### PR TITLE
Catch all SOAPFaults in BGS::Base

### DIFF
--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -69,15 +69,6 @@ module BGS
     def can_access?(ssn)
       claimants.find_flashes(ssn).nil?
       true
-    rescue Savon::SOAPFault => e
-      # Expect error string to look something like the following:
-      # Savon::SOAPFault: (S:Client) ID: {{UUID}}: Logon ID {{CSS_ID}} Not Found
-      # Only extract the final clause of that error message for the public error.
-      #
-      # rubocop:disable Metrics/LineLength
-      raise(BGS::PublicError, "#{Regexp.last_match(1)} in the Benefits Gateway Service (BGS). Contact your ISO if you need assistance gaining access to BGS.") if e.to_s =~ /(Logon ID .* Not Found)/
-      # rubocop:enable Metrics/LineLength
-      raise e
     rescue BGS::ShareError
       false
     end


### PR DESCRIPTION
`BGS::PersonWebService.find_by_file_number()` [is raising a Savon::SOAPFault](https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/1169/). We [previously fixed the same issue](https://github.com/department-of-veterans-affairs/ruby-bgs/commit/8c36e65cfec998ac9dcef4cb2caa433c2d0c5550) for calls to `BGS::Services.can_access?()` and apply the same fix here closer to the code that actually raises this exception so that all BGS requests can benefit from this error handling.

This error is currently resulting efolder [sending a 500 response](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/b8985ac7c5f9b6df7f67d5d33802cc982a57d5bb/app/controllers/api/v1/application_controller.rb#L5) to the client (efolder front-end or caseflow). This change will instead [return a more precise 403 response](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/b8985ac7c5f9b6df7f67d5d33802cc982a57d5bb/app/controllers/api/v1/application_controller.rb#L16). On the caseflow side, this will allow us to respond with a [more precise error](https://github.com/department-of-veterans-affairs/caseflow/blob/504e9de218501d91b3c857ac1f7338796bb594d0/app/services/external_api/efolder_service.rb#L19) as well.

As for the tradeoffs that come with changing more `Savon::SOAPFault`s into `BGS::PublicError`s, I don't think we lose any precision or change any behaviour except for the cases where we already expect to be throwing `BGS::PublicError`s. There is no code in [efolder](https://github.com/department-of-veterans-affairs/caseflow-efolder/search?utf8=%E2%9C%93&q=Savon%3A%3ASOAPFault&type=) that expects `Savon::SOAPFault`s and [the only code in caseflow](https://github.com/department-of-veterans-affairs/caseflow/blob/6b664abfd080307cf8862c7d094b297b6d203c63/app/models/power_of_attorney.rb#L44) that expects a `Savon::SOAPFault` will not be affected because the error string will not match `Logon ID .* Not Found`.