### PR TITLE
Add mass poas query

### DIFF
--- a/lib/bgs/services/org.rb
+++ b/lib/bgs/services/org.rb
@@ -35,5 +35,11 @@ module BGS
       response = request(:find_po_as_by_ptcpnt_id, "ptcpntId": participant_id)
       response.body[:find_po_as_by_ptcpnt_id_response][:return]
     end
+
+    # batch find poas based on participant ids
+    def find_poas_by_ptcpnt_ids(participant_ids)
+      response = request(:find_po_as_by_ptcpnt_ids, "ptcpntIds": participant_ids)
+      response.body[:find_po_as_by_ptcpnt_ids_response][:return]
+    end
   end
 end

--- a/lib/bgs/services/security.rb
+++ b/lib/bgs/services/security.rb
@@ -5,7 +5,7 @@ module BGS
     end
 
     # Gets a users' participant id from their station and css ids
-    def find_ptcpnt_id(station_id:, css_id:)
+    def find_participant_id(station_id:, css_id:)
       response = request(:find_ptcpnt_id, "stationNumber": station_id, "userId": css_id)
       response.body[:find_ptcpnt_id_response][:return]
     end


### PR DESCRIPTION
Expose an endpoint to query for multiple POAs at once. This way we can batch get POA info.