### PR TITLE
Do not look for return in response

### DIFF
--- a/lib/bgs/services/org.rb
+++ b/lib/bgs/services/org.rb
@@ -46,7 +46,7 @@ module BGS
     # find claim-level limited POA
     def find_limited_poas_by_bnft_claim_ids(claim_id)
       response = request(:find_limited_poas_by_bnft_claim_ids, "bnftClaimId": claim_id)
-      response.body[:find_limited_poas_by_bnft_claim_ids_response]
+      response.body[:find_limited_poas_by_bnft_claim_ids_response][:limited_poa]
     end
   end
 end

--- a/lib/bgs/services/org.rb
+++ b/lib/bgs/services/org.rb
@@ -46,7 +46,7 @@ module BGS
     # find claim-level limited POA
     def find_limited_poas_by_bnft_claim_ids(claim_id)
       response = request(:find_limited_poas_by_bnft_claim_ids, "bnftClaimId": claim_id)
-      response.body[:find_limited_poas_by_bnft_claim_ids_response][:return]
+      response.body[:find_limited_poas_by_bnft_claim_ids_response]
     end
   end
 end


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/caseflow/issues/9142

Doh! Unlike every other BGS call, there's no "return" in the response for limited_poa