### PR TITLE
Update nokogiri to 1.10.1

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = "paul.tagliamonte@va.gov"
   gem.homepage      = ""
 
-  gem.add_runtime_dependency "nokogiri", "~> 1.8.2"
+  gem.add_runtime_dependency "nokogiri", "~> 1.10"
   gem.add_runtime_dependency "savon", "~> 2.11"
 
   gem.files         = Dir["lib/**/*.rb"]


### PR DESCRIPTION
**Why**: To allow the caseflow repo to update its nokogiri version to
1.10.1, which contains many bug fixes and performance improvements.

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md