### PR TITLE
Auto retry connection errors

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = ""
 
   gem.add_runtime_dependency "nokogiri", "~> 1.10"
-  gem.add_runtime_dependency "savon", "~> 2.11"
+  gem.add_runtime_dependency "savon", "~> 2.12"
+  gem.add_runtime_dependency "httpclient"
 
   gem.files         = Dir["lib/**/*.rb"]
   gem.require_paths = ["lib"]

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -6,6 +6,7 @@
 
 require "savon"
 require "nokogiri"
+require "httpclient"
 
 module BGS
   # This error is raised when the BGS SOAP API returns a ShareException
@@ -149,8 +150,6 @@ module BGS
 
     # Proxy to call a method on our web service.
     def request(method, message = nil)
-      # can be removed when savon > 2.11.2 is released
-      client.wsdl.request.headers = { "Host" => domain } if @forward_proxy_url
       client.call(method, message: message)
     rescue HTTPClient::ConnectTimeoutError, HTTPClient::ReceiveTimeoutError, Errno::ETIMEDOUT => _err
       # re-try once assuming this was a server-side hiccup


### PR DESCRIPTION
We see `Errno::ETIMEDOUT: Connection timed out - connect(2)` errors randomly throughout the day, and we think these are server-side hiccups.

This PR does a few things:

* upgrade Savon to latest
* changes the connect timeout from 10 minutes to 10 seconds, under the assumption that connecting should be nearly instantaneous and we'd rather fail early
* automatically re-try once on connect failure.