### PR TITLE
Rename `transient?` to `ignorable?`

### DIFF
--- a/lib/bgs/errors.rb
+++ b/lib/bgs/errors.rb
@@ -100,7 +100,7 @@ module BGS
       super(@message)
     end
 
-    def transient?
+    def ignorable?
       TRANSIENT_ERRORS.any? { |transient_error| message.include?(transient_error) }
     end
   end

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -79,7 +79,7 @@ describe BGS::Base do
         expect(error.class).to eq BGS::ShareError
         expect(error.message).to eq message
         expect(error.code).to eq 500
-        expect(error).to be_transient
+        expect(error).to be_ignorable
       end
      end
   end
@@ -109,7 +109,7 @@ describe BGS::Base do
         expect(error.class).to eq BGS::ShareError
         expect(error.message).to eq message
         expect(error.code).to eq 500
-        expect(error).to_not be_transient
+        expect(error).to_not be_ignorable
       end
      end
   end


### PR DESCRIPTION
**Why**: We want to identify errors that can be ignored from services
like Sentry, whether they are transient or some other type of known,
non-actionable error.