### PR TITLE
BGS::TransientError

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = "paul.tagliamonte@va.gov"
   gem.homepage      = ""
 
-  gem.add_runtime_dependency "nokogiri", "~> 1.10"
+  gem.add_runtime_dependency "nokogiri", "~> 1.10.4"
   gem.add_runtime_dependency "savon", "~> 2.12"
   gem.add_runtime_dependency "httpclient"
 

--- a/lib/bgs/errors.rb
+++ b/lib/bgs/errors.rb
@@ -105,6 +105,12 @@ module BGS
     end
   end
 
+  class TransientError < ShareError
+    def ignorable?
+      true
+    end
+  end
+
   class PublicError < StandardError
     attr_accessor :public_message
 

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -28,7 +28,7 @@ describe BGS::Base do
     it "re-tries one time" do
       allow_any_instance_of(Savon::Client).to receive(:call).and_raise(timeout_error)
       expect(bgs_base).to receive(:client).twice.and_call_original
-      expect { bgs_base.test_request(:method) }.to raise_error(Errno::ETIMEDOUT)
+      expect { bgs_base.test_request(:method) }.to raise_error(BGS::TransientError)
     end
   end
 


### PR DESCRIPTION
Typically we identify "transient" errors by pattern matching on the exception message.

This PR adds a new explicit `TransientError` class where `ignorable?` always returns true, and wraps any of our automatic retry triggering exceptions in that class if the retry should fail.