### PR TITLE
Use hash.dig rather than assuming hash structure

### DIFF
--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -154,7 +154,7 @@ module BGS
       end
 
       # special case
-      raise_public_error(message) if message =~ /(Logon ID .* Not Found)/
+      raise_public_error(Regexp.last_match(1)) if message =~ /(Logon ID .* Not Found)/
 
       raise BGS::ShareError.new_from_message(message, code)
     end

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -144,7 +144,8 @@ module BGS
     end
 
     def handle_request_error(error)
-      message = error.to_hash[:fault][:detail][:share_exception][:message]
+      err_tree = error.to_hash
+      message = err_tree.dig(:fault, :detail, :share_exception, :message) || err_tree.dig(:fault, :faultstring)
       code = error.http.code
 
       raise BGS::ShareError.new_from_message(message, code)


### PR DESCRIPTION
BGS can return an error message like:

```ruby
{:fault=>
  {:faultcode=>"S:Server",
   :faultstring=>"gov.va.vba.utils.ShareException",
   :detail=>
    {:share_exception=>
      {:"@xmlns:ns2"=>"http://services.share.benefits.vba.va.gov/"}},
   :"@xmlns:ns4"=>"http://www.w3.org/2003/05/soap-envelope"}}
```

which the current error handling will fumble. Use the Ruby `.dig` method and try multiple possible combinations to look for an error message.

Verified in production for the `findVeteranByFileNumber` service.