### PR TITLE
Update rating profile response for new service

### DIFF
--- a/lib/bgs/services/rating_profile.rb
+++ b/lib/bgs/services/rating_profile.rb
@@ -32,7 +32,7 @@ module BGS
         "startDate": start_date,
         "endDate": end_date
       )
-      result = response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range]
+      response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range]
     end
   end
 end

--- a/lib/bgs/services/rating_profile.rb
+++ b/lib/bgs/services/rating_profile.rb
@@ -32,7 +32,7 @@ module BGS
         "startDate": start_date,
         "endDate": end_date
       )
-      response.body
+      response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range][:rba_profile_list][:rba_profile]
     end
   end
 end

--- a/lib/bgs/services/rating_profile.rb
+++ b/lib/bgs/services/rating_profile.rb
@@ -32,7 +32,7 @@ module BGS
         "startDate": start_date,
         "endDate": end_date
       )
-      response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range][:rba_profile_list][:rba_profile]
+      result = response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range]
     end
   end
 end


### PR DESCRIPTION
When we added this service there was some uncertainty as to how the response might look in prod due to limited UAT data. Updating now based on examples from prod.

I double checked examples with 0 ratings, 1 rating, and multiple ratings, and the added sections in this PR are always present.  Beyond that it starts to vary.