### PR TITLE
Override SOAP WSDL endpoint

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "nokogiri", "~> 1.10.4"
   gem.add_runtime_dependency "savon", "~> 2.12"
   gem.add_runtime_dependency "httpclient"
+  gem.add_development_dependency "pry"
+  gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "byebug"
 
   gem.files         = Dir["lib/**/*.rb"]
   gem.require_paths = ["lib"]

--- a/lib/bgs/base.rb
+++ b/lib/bgs/base.rb
@@ -56,6 +56,10 @@ module BGS
       nil # default comes from wsdl
     end
 
+    def endpoint
+      nil # default comes from wsdl
+    end
+
     private
 
     def https?
@@ -138,6 +142,7 @@ module BGS
         convert_request_keys_to: :none
       }
       savon_client_params[:namespace_identifier] = namespace_identifier if namespace_identifier
+      savon_client_params[:endpoint] = endpoint if endpoint
 
       @client ||= Savon.client(savon_client_params)
     end

--- a/lib/bgs/services/common_security.rb
+++ b/lib/bgs/services/common_security.rb
@@ -8,8 +8,14 @@ module BGS
       "css-webservices"
     end
 
+    # override what's in the wsdl
     def namespace_identifier
       "v1"
+    end
+
+    # override what's in the wsdl
+    def endpoint
+      "#{base_url}/#{bean_name}/#{@service_name}"
     end
 
     def get_css_user_stations(username)

--- a/lib/bgs/services/common_security.rb
+++ b/lib/bgs/services/common_security.rb
@@ -8,6 +8,8 @@ module BGS
       "css-webservices"
     end
 
+    # ideally BGS would fix the WSDL for this service to conform with how their own WSDLs work.
+
     # override what's in the wsdl
     def namespace_identifier
       "v1"

--- a/spec/bgs/base_spec.rb
+++ b/spec/bgs/base_spec.rb
@@ -1,4 +1,5 @@
 require "bgs"
+require "pry"
 
 def default_soap_body(message)
   %(<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
@@ -145,6 +146,22 @@ describe BGS::Base do
       end
     end
   end
+
+  context "explicit endpoint" do
+    before do
+      allow_any_instance_of(Savon::Client).to receive(:call) do |client, soap_method|
+        @endpoint_used = client.wsdl.endpoint
+        true
+      end
+    end
+
+    it "uses the explicit subclass endpoint in requests" do
+      expect(bgs_base.endpoint).to eq "override-the-wsdl"
+      expect(bgs_base.send(:client).wsdl.endpoint).to eq "override-the-wsdl"
+      expect(bgs_base.test_request(:method)).to eq true
+      expect(@endpoint_used).to eq "override-the-wsdl"
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength
 
@@ -153,6 +170,10 @@ module BGS
   class TestBase < BGS::Base
     def test_request(method, message = nil)
       request(method, message)
+    end
+
+    def endpoint
+      "override-the-wsdl"
     end
   end
 end


### PR DESCRIPTION
BGS has the wrong value in their WSDL in production, so we cannot trust it.

This PR allows us to override the WSDL endpoint with whatever logic we need to, per-service.

I have tested in UAT and production.