### PR TITLE
Intake | Add Contention service to ruby-bgs 

### DIFF
--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -28,7 +28,6 @@ require "bgs/services/veteran"
 require "bgs/services/security"
 require "bgs/services/contention"
 
-
 # Now, we're going to declare a class to hide the actual creation of service
 # objects, since having to construct them all really sucks.
 

--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -26,6 +26,8 @@ require "bgs/services/rating_profile"
 require "bgs/services/standard_data"
 require "bgs/services/veteran"
 require "bgs/services/security"
+require "bgs/services/contention"
+
 
 # Now, we're going to declare a class to hide the actual creation of service
 # objects, since having to construct them all really sucks.

--- a/lib/bgs/services/contention.rb
+++ b/lib/bgs/services/contention.rb
@@ -1,0 +1,46 @@
+# As a work of the United States Government, this project is in the
+# public domain within the United States.
+#
+# Additionally, we waive copyright and related rights in the work
+# worldwide through the CC0 1.0 Universal public domain dedication.
+
+module BGS
+  # This service gets information about a veteran's contention.
+  class ContentionWebService < BGS::Base
+    def bean_name
+      "ContentionService"
+    end
+
+    def self.service_name
+      "contention"
+    end
+
+    # Find contention by claim_id.
+    def find_contention_by_claim_id(claim_id)
+      response = request(:find_contentions, "claimId": claim_id)
+      response.body[:find_contentions_response][:benefit_claim]
+    end
+
+    # # Find a Person, as defined by the Person Web Service, by their File
+    # # Number.
+    # def find_by_file_number(file_number)
+    #   response = request(:find_person_by_file_number, "fileNumber": file_number)
+    #   response.body[:find_person_by_file_number_response][:person_dto]
+    # end
+
+    # def find_person_by_ptcpnt_id(participant_id)
+    #   response = request(:find_person_by_ptcpnt_id, "ptcpntId": participant_id)
+    #   response.body[:find_person_by_ptcpnt_id_response][:person_dto]
+    # end
+
+    # def find_relationships_by_ptcpnt_id_relationship_type(participant_id, type)
+    #   response = request(:find_relationships_by_ptcpnt_id_relationship_type, "ptcpntId": participant_id, "type": type)
+    #   response.body[:find_relationships_by_ptcpnt_id_relationship_type_response][:person_dto]
+    # end
+
+    # def find_employee_by_participant_id(participant_id)
+    #   response = request(:find_employee_by_ptcpnt_id, "ptcpntId": participant_id)
+    #   response.body[:find_employee_by_ptcpnt_id_response][:employee_dto]
+    # end
+  end
+end

--- a/lib/bgs/services/contention.rb
+++ b/lib/bgs/services/contention.rb
@@ -20,27 +20,5 @@ module BGS
       response = request(:find_contentions, "claimId": claim_id)
       response.body[:find_contentions_response][:benefit_claim]
     end
-
-    # # Find a Person, as defined by the Person Web Service, by their File
-    # # Number.
-    # def find_by_file_number(file_number)
-    #   response = request(:find_person_by_file_number, "fileNumber": file_number)
-    #   response.body[:find_person_by_file_number_response][:person_dto]
-    # end
-
-    # def find_person_by_ptcpnt_id(participant_id)
-    #   response = request(:find_person_by_ptcpnt_id, "ptcpntId": participant_id)
-    #   response.body[:find_person_by_ptcpnt_id_response][:person_dto]
-    # end
-
-    # def find_relationships_by_ptcpnt_id_relationship_type(participant_id, type)
-    #   response = request(:find_relationships_by_ptcpnt_id_relationship_type, "ptcpntId": participant_id, "type": type)
-    #   response.body[:find_relationships_by_ptcpnt_id_relationship_type_response][:person_dto]
-    # end
-
-    # def find_employee_by_participant_id(participant_id)
-    #   response = request(:find_employee_by_ptcpnt_id, "ptcpntId": participant_id)
-    #   response.body[:find_employee_by_ptcpnt_id_response][:employee_dto]
-    # end
   end
 end


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/caseflow/issues/13488

- [ ] Update `ruby-bgs/lib/bgs/services.rb` to include the new service

`client.contention.find_contention_by_claim_id(claim_id)`
<img width="1304" alt="Screen Shot 2020-03-11 at 12 10 46 PM" src="https://user-images.githubusercontent.com/23080951/76439125-4e677700-6392-11ea-82ce-71e2f48797c7.png">

<img width="1188" alt="Screen Shot 2020-03-11 at 11 59 03 AM" src="https://user-images.githubusercontent.com/23080951/76439194-6939eb80-6392-11ea-88cf-67430466b62b.png">
