### PR TITLE
Add BenefitClaimWebServiceBean class

### DIFF
--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -16,6 +16,7 @@
 require "bgs/services/address"
 require "bgs/services/awards"
 require "bgs/services/benefit"
+require "bgs/services/benefit_claim"
 require "bgs/services/claimant"
 require "bgs/services/common_security"
 require "bgs/services/document"

--- a/lib/bgs/services/benefit.rb
+++ b/lib/bgs/services/benefit.rb
@@ -1,5 +1,5 @@
 module BGS
-  class BenefitClaimWebService < BGS::Base
+  class BenefitClaimService < BGS::Base
     def bean_name
       "BenefitClaimServiceBean"
     end

--- a/lib/bgs/services/benefit_claim.rb
+++ b/lib/bgs/services/benefit_claim.rb
@@ -1,0 +1,16 @@
+module BGS
+  class BenefitClaimWebService < BGS::Base
+    def bean_name
+      "BenefitClaimWebServiceBean"
+    end
+
+    def self.service_name
+      "benefit_claims"
+    end
+
+    def find_claim_by_file_number(file_number)
+      response = request(:find_bnft_claim_by_file_number, "fileNumber": file_number)
+      response.body[:find_bnft_claim_by_file_number_response][:bnft_claim_dto]
+    end
+  end
+end


### PR DESCRIPTION
This is what VBMS uses to determine POA for claimants.

https://dsva.slack.com/archives/CK466V65V/p1588717423021100?thread_ts=1588602553.016500&cid=CK466V65V

Apparently BGS has 2 services:
* BenefitClaimWebServiceBean
* BenefitClaimServiceBean

and our class was misnamed.