### PR TITLE
Add AcountLocked error

### DIFF
--- a/lib/bgs/errors.rb
+++ b/lib/bgs/errors.rb
@@ -100,6 +100,7 @@ module BGS
       # https://github.com/department-of-veterans-affairs/caseflow/issues/12166
       "BGS::NoRecordsReturned" => /No records returned/,
       "BGS::NoRatingsExistForVeteran" => /No Ratings exist for this Veteran/,
+      "BGS::AccountLocked" => /Your account is locked/
     }.freeze
 
     attr_reader :message, :code
@@ -147,4 +148,6 @@ module BGS
   class NoRecordsReturned < ShareError; end
 
   class NoRatingsExistForVeteran < ShareError; end
+
+  class AccountLocked < ShareError; end
 end


### PR DESCRIPTION
Add AccountLocked as subclass of BGS::ShareError so that it can be handled by Caseflow's [IDT Controller](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/controllers/idt/api/v1/base_controller.rb) and an appropriate HTTP error code is returned (instead of 500).

[convo](https://dsva.slack.com/archives/C4JECDLSE/p1593612519009900?thread_ts=1593549147.001300&cid=C4JECDLSE)