### PR TITLE
Intake | Missing Ratings | Add current rating profile

### DIFF
--- a/lib/bgs/services/rating_profile.rb
+++ b/lib/bgs/services/rating_profile.rb
@@ -34,5 +34,11 @@ module BGS
       )
       response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range]
     end
+    
+    # Returns current rating profile by file number
+    def get_current_rating_profile(file_number, include_issues=false)
+      response = request(:read_current_rating_profile, "veteranId": file_number, "includeIssues": include_issues)
+      response.body[:read_current_rating_profile_response][:rba_profile]
+    end
   end
 end

--- a/lib/bgs/services/rating_profile.rb
+++ b/lib/bgs/services/rating_profile.rb
@@ -35,10 +35,11 @@ module BGS
       response.body[:get_all_decns_at_issue_for_date_range_response][:decns_at_issue_for_date_range]
     end
     
-    # Returns current rating profile by file number
-    def get_current_rating_profile(file_number, include_issues=false)
-      response = request(:read_current_rating_profile, "veteranId": file_number, "includeIssues": include_issues)
-      response.body[:read_current_rating_profile_response][:rba_profile]
+    # Returns current rating profile by participant_id
+    def find_current_rating_profile_by_ptcpnt_id(participant_id, include_issues=true)
+      response = request(:read_current_rating_profile_by_ptcpnt_id, "veteranId": participant_id, "includeIssues": include_issues)
+      response.body[:read_current_rating_profile_by_ptcpnt_id_response][:rba_profile]
     end
   end
 end
+


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/14653

**Description**
- [ ] Add RatingInformationService.read_current_rating_profile to ruby-bgs repo
  - [ ] Service name: RatingInformationService
  - [ ] Inputs:
    - [ ] fileNumber (varchar)
    - [ ] includeIssues (boolean)

<img width="1421" alt="Screen Shot 2020-07-16 at 3 13 58 PM" src="https://user-images.githubusercontent.com/23080951/87714962-96503d80-c77a-11ea-8ee1-6ba501f4eb08.png">
