### PR TITLE
Add ShareStandardDataService class

### DIFF
--- a/lib/bgs/services.rb
+++ b/lib/bgs/services.rb
@@ -30,6 +30,7 @@ require "bgs/services/standard_data"
 require "bgs/services/veteran"
 require "bgs/services/security"
 require "bgs/services/contention"
+require "bgs/services/share_standard_data"
 
 # Now, we're going to declare a class to hide the actual creation of service
 # objects, since having to construct them all really sucks.

--- a/lib/bgs/services/share_standard_data.rb
+++ b/lib/bgs/services/share_standard_data.rb
@@ -1,0 +1,16 @@
+module BGS
+  class ShareStandardDataService < BGS::Base
+    def bean_name
+      "ShareStandardDataServiceBean"
+    end
+
+    def self.service_name
+      "share_standard_data"
+    end
+
+    def find_diagnostic_codes(file_number)
+      response = request(:find_diagnostic_codes, "fileNumber": file_number)
+      response.body[:find_diagnostic_codes_response]
+    end
+  end
+end


### PR DESCRIPTION
Resolves #14870 (caseflow repo)

Add the ShareStandardDataService endpoint in order to use the find_diagnostic_codes method to properly retrieve diagnostic code descriptions in Caseflow.  Documentation located in the [BGS-API-DOCS](https://github.com/department-of-veterans-affairs/appeals-team/tree/master/Project%20Folders/Caseflow%20Projects/Intake/BGS-VBMS/BGS-API-Docs)

```ruby
client.share_standard_data.find_diagnostic_codes(uat_file_number)
```
<img width="1438" alt="Screen Shot 2020-08-04 at 5 06 42 PM" src="https://user-images.githubusercontent.com/18618189/89345108-e719ce80-d674-11ea-9e8f-25542e192f9e.png">
