### PR TITLE
remove argument from find_diagnostic_codes method

### DIFF
--- a/lib/bgs/services/share_standard_data.rb
+++ b/lib/bgs/services/share_standard_data.rb
@@ -8,8 +8,8 @@ module BGS
       "share_standard_data"
     end
 
-    def find_diagnostic_codes(file_number)
-      response = request(:find_diagnostic_codes, "fileNumber": file_number)
+    def find_diagnostic_codes
+      response = request(:find_diagnostic_codes)
       response.body[:find_diagnostic_codes_response]
     end
   end


### PR DESCRIPTION
Remove unnecessary argument from the find_diagnostic_codes method that was added in #103 