### PR TITLE
Update nokogiri due to security advisory

### DIFF
--- a/bgs.gemspec
+++ b/bgs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = "vacaseflowops@va.gov"
   gem.homepage      = ""
 
-  gem.add_runtime_dependency "nokogiri", "~> 1.10.8"
+  gem.add_runtime_dependency "nokogiri", ">= 1.11.0.rc4"
   gem.add_runtime_dependency "savon", "~> 2.12"
   gem.add_runtime_dependency "httpclient"
   gem.add_development_dependency "bundler-audit"


### PR DESCRIPTION
Update nokogiri to address security advisory and unblock linting.

After this, ruby-bgs should be updated in Caseflow's gemfile, as well as Nokogiri.

CVE-2020-26247
https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m